### PR TITLE
Start RPC server when starting backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,6 +2332,7 @@ dependencies = [
  "diesel",
  "dotenvy",
  "lazy_static",
+ "proto",
  "reqwest",
  "serde",
  "serde_json",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,8 +2,12 @@
 name = "server"
 version = "0.1.0"
 edition = "2021"
+default-run = "server"
 
 [dependencies]
+# Local
+olly_proto = { package = "proto", path = "../proto" }
+
 axum = "0.7.5"
 chrono = "0.4.38"
 deno_core = "0.289.0"


### PR DESCRIPTION
Uses the RPC server defined in the `proto` crate in `server`.