### PR TITLE
improve CI times

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -1,9 +1,13 @@
 name: Build and Test
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   build-test-lint:
@@ -25,17 +29,17 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
-          github_token: ${{ secrets.SYNC_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup buf
         uses: bufbuild/buf-setup-action@v1.34.0
         with:
-          github_token: ${{ secrets.SYNC_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check
-        run: cargo check
+      - name: Check and Build
+        run: cargo build
 
-      - name: Build and run tests
+      - name: Run tests
         run: cargo test
 
       - name: Clippy

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -1,113 +1,46 @@
 name: Build and Test
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
-env:
-  CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-D warnings"
-
 jobs:
-  check:
+  build-test-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-        components: rustfmt, clippy
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
 
-    - uses: arduino/setup-protoc@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
 
-    - name: Install buf
-      uses: bufbuild/buf-setup-action@v1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          github_token: ${{ secrets.SYNC_TOKEN }}
 
-    - name: Add buf to PATH
-      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Setup buf
+        uses: bufbuild/buf-setup-action@v1.34.0
+        with:
+          github_token: ${{ secrets.SYNC_TOKEN }}
 
-    - name: Verify buf installation
-      run: |
-        which buf
-        buf --version
+      - name: Check
+        run: cargo check
 
-    - uses: Swatinem/rust-cache@v2
+      - name: Build and run tests
+        run: cargo test
 
-    - name: Check formatting
-      run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy -- -D warnings
 
-    - name: Run clippy
-      run: cargo clippy --all-targets --all-features
-
-  test:
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-
-    - name: Install buf
-      uses: bufbuild/buf-setup-action@v1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Add buf to PATH
-      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-    - name: Verify buf installation
-      run: |
-        which buf
-        buf --version
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Run tests
-      run: cargo test --all-features
-
-    - name: Debug - List proto directory
-      if: failure()
-      run: ls -R proto
-
-  build:
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-
-    - name: Install buf
-      uses: bufbuild/buf-setup-action@v1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Add buf to PATH
-      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-    - name: Verify buf installation
-      run: |
-        which buf
-        buf --version
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Build
-      run: cargo build --release --all-features
-
-    - name: Debug - List proto directory
-      if: failure()
-      run: ls -R proto
+      - name: Format check
+        run: cargo fmt -- --check
 

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -1,5 +1,4 @@
 name: Build and Test
-
 on:
   push:
     branches: [ main ]
@@ -7,67 +6,53 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-
+  check:
     runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        working-directory: ./
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - name: Check
+        run: cargo check
 
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-        components: rustfmt, clippy
+  test:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - uses: arduino/setup-protoc@v3
+        with:
+          github_token: ${{ secrets.SYNC_TOKEN }}
+      - uses: bufbuild/buf-setup-action@v1.34.0
+        with:
+          github_token: ${{ secrets.SYNC_TOKEN }}
+      - name: Run tests
+        run: cargo test
 
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        github_token: ${{ secrets.SYNC_TOKEN }}
-
-    - name: Setup buf
-      uses: bufbuild/buf-setup-action@v1.34.0
-      with:
-        github_token: ${{ secrets.SYNC_TOKEN }}
-
-    - name: Cache Cargo registry
-      uses: actions/cache@v2
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-registry-
-
-    - name: Cache Cargo index
-      uses: actions/cache@v2
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-index-
-
-    - name: Cache Cargo build
-      uses: actions/cache@v2
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-
-
-    - name: Build
-      run: cargo build --verbose
-
-    - name: Run tests
-      run: cargo test --verbose
-
-    - name: Run Clippy
-      run: cargo clippy -- -D warnings
-
-    - name: Run Rustfmt
-      run: cargo fmt -- --check
+  lints:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+      - name: Format check
+        run: cargo fmt -- --check
 

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -1,58 +1,71 @@
 name: Build and Test
+
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v2
-      - name: Check
-        run: cargo check
+    - uses: actions/checkout@v3
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        components: rustfmt, clippy
+
+    - uses: arduino/setup-protoc@v3
+      with:
+        github_token: ${{ secrets.SYNC_TOKEN }}
+
+    - uses: bufbuild/buf-setup-action@v1
+      with:
+        github_token: ${{ secrets.SYNC_TOKEN }}
+
+    - uses: Swatinem/rust-cache@v2
+
+    - name: Check formatting
+      run: cargo fmt --all -- --check
+
+    - name: Run clippy
+      run: cargo clippy --all-targets --all-features
 
   test:
-    runs-on: ubuntu-latest
     needs: check
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v2
-      - uses: arduino/setup-protoc@v3
-        with:
-          github_token: ${{ secrets.SYNC_TOKEN }}
-      - uses: bufbuild/buf-setup-action@v1.34.0
-        with:
-          github_token: ${{ secrets.SYNC_TOKEN }}
-      - name: Run tests
-        run: cargo test
-
-  lints:
     runs-on: ubuntu-latest
-    needs: check
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
-      - name: Clippy
-        run: cargo clippy -- -D warnings
-      - name: Format check
-        run: cargo fmt -- --check
+    - uses: actions/checkout@v3
 
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - uses: Swatinem/rust-cache@v2
+
+    - name: Run tests
+      run: cargo test --all-features
+
+  build:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - uses: Swatinem/rust-cache@v2
+
+    - name: Build
+      run: cargo build --release --all-features

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -24,11 +24,20 @@ jobs:
 
     - uses: arduino/setup-protoc@v3
       with:
-        github_token: ${{ secrets.SYNC_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: bufbuild/buf-setup-action@v1
+    - name: Install buf
+      uses: bufbuild/buf-setup-action@v1
       with:
-        github_token: ${{ secrets.SYNC_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Add buf to PATH
+      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Verify buf installation
+      run: |
+        which buf
+        buf --version
 
     - uses: Swatinem/rust-cache@v2
 
@@ -49,10 +58,26 @@ jobs:
         toolchain: stable
         override: true
 
+    - name: Install buf
+      uses: bufbuild/buf-setup-action@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Add buf to PATH
+      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Verify buf installation
+      run: |
+        which buf
+        buf --version
     - uses: Swatinem/rust-cache@v2
 
     - name: Run tests
       run: cargo test --all-features
+
+    - name: Debug - List proto directory
+      if: failure()
+      run: ls -R proto
 
   build:
     needs: check
@@ -65,7 +90,24 @@ jobs:
         toolchain: stable
         override: true
 
+    - name: Install buf
+      uses: bufbuild/buf-setup-action@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Add buf to PATH
+      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Verify buf installation
+      run: |
+        which buf
+        buf --version
     - uses: Swatinem/rust-cache@v2
 
     - name: Build
       run: cargo build --release --all-features
+
+    - name: Debug - List proto directory
+      if: failure()
+      run: ls -R proto
+

--- a/proto/src/examples/mod.rs
+++ b/proto/src/examples/mod.rs
@@ -25,7 +25,7 @@ mod tests {
         let (tx, rx): (oneshot::Sender<()>, oneshot::Receiver<()>) = oneshot::channel();
 
         let server_handle: JoinHandle<()> = tokio::spawn(async move {
-            let server: DummyRpcServer = DummyRpcServer::new(addr.clone()).await;
+            let server: DummyRpcServer = DummyRpcServer::new(addr).await;
 
             tx.send(()).unwrap();
             server.serve().await.unwrap();
@@ -48,7 +48,7 @@ mod tests {
         let (tx, rx): (oneshot::Sender<()>, oneshot::Receiver<()>) = oneshot::channel();
 
         let server_handle: JoinHandle<()> = tokio::spawn(async move {
-            let server: DummyRpcServer = DummyRpcServer::new(addr.clone()).await;
+            let server: DummyRpcServer = DummyRpcServer::new(addr).await;
 
             tx.send(()).unwrap();
             server.serve().await.unwrap();


### PR DESCRIPTION
Our CI times on `main` are quite slow, taking over 15 minutes: https://github.com/ollyLLM/backend/actions/runs/10648057804/job/29516696234

This PR updates the following:
- Uses `GITHUB_TOKEN` instead of `SYNC_TOKEN` (only needed for the sync-proto workflow)
- Simplifies caching, relying on `Swatinem/rust-cache@v2`
- More concise Rust toolchain installation step
- Removed `--verbose`

The result after these changes is a ~4-5 minute regular execution time, and ~1 minute when cargo dependencies are cached.